### PR TITLE
Add common HTTP errors

### DIFF
--- a/http.js
+++ b/http.js
@@ -1,0 +1,89 @@
+const OError = require('./index')
+
+class HttpError extends OError {
+  constructor(options) {
+    super(options)
+    this.statusCode = options.statusCode || 500
+  }
+}
+
+class InternalServerError extends HttpError {
+  constructor(options) {
+    super({ message: 'Internal Server Error', statusCode: 500, ...options })
+  }
+}
+
+class ServiceUnavailableError extends HttpError {
+  constructor(options) {
+    super({ message: 'Service Unavailable', statusCode: 503, ...options })
+  }
+}
+
+class BadRequestError extends HttpError {
+  constructor(options) {
+    super({ message: 'Bad Request', statusCode: 400, ...options })
+  }
+}
+
+class UnauthorizedError extends HttpError {
+  constructor(options) {
+    super({ message: 'Unauthorized', statusCode: 401, ...options })
+  }
+}
+
+class ForbiddenError extends HttpError {
+  constructor(options) {
+    super({ message: 'Forbidden', statusCode: 403, ...options })
+  }
+}
+
+class NotFoundError extends HttpError {
+  constructor(options) {
+    super({ message: 'Not Found', statusCode: 404, ...options })
+  }
+}
+
+class MethodNotAllowedError extends HttpError {
+  constructor(options) {
+    super({ message: 'Method Not Allowed', statusCode: 405, ...options })
+  }
+}
+
+class NotAcceptableError extends HttpError {
+  constructor(options) {
+    super({ message: 'Not Acceptable', statusCode: 406, ...options })
+  }
+}
+
+class ConflictError extends HttpError {
+  constructor(options) {
+    super({ message: 'Conflict', statusCode: 409, ...options })
+  }
+}
+
+class UnprocessableEntityError extends HttpError {
+  constructor(options) {
+    super({ message: 'Unprocessable Entity', statusCode: 422, ...options })
+  }
+}
+
+class TooManyRequestsError extends HttpError {
+  constructor(options) {
+    super({ message: 'Too Many Requests', statusCode: 429, ...options })
+  }
+}
+
+module.exports = {
+  HttpError,
+  InternalServerError,
+  ServiceUnavailableError,
+  BadRequestError,
+  UnauthorizedError,
+  ForbiddenError,
+  NotFoundError,
+  MethodNotAllowedError,
+  NotAcceptableError,
+  ConflictError,
+  UnprocessableEntityError,
+  TooManyRequestsError
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@overleaf/o-error",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overleaf/o-error",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Make custom error types that pass `instanceof` checks, have stack traces, support custom messages and properties, and can wrap causes (like VError).",
   "main": "index.js",
   "scripts": {

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -1,0 +1,20 @@
+const OError = require('..')
+const HttpErrors = require('../http')
+
+describe('OError/http', () => {
+  it('is instance of OError', () => {
+    try {
+      throw new HttpErrors.ConflictError()
+    } catch (e) {
+      expect(e).to.be.instanceof(OError)
+    }
+  })
+
+  it('has status code', () => {
+    try {
+      throw new HttpErrors.ConflictError()
+    } catch (e) {
+      expect(e.statusCode).to.equal(409)
+    }
+  })
+})


### PR DESCRIPTION
- required via `@overleaf/o-error/http`
- only most common and relevant HTTP status codes added
- data comes from Wikipedia (https://en.wikipedia.org/wiki/List_of_HTTP_status_codes)
- bumped version to `2.1.0`