### PR TITLE
Fix incorrect expect

### DIFF
--- a/test/support/index.js
+++ b/test/support/index.js
@@ -24,7 +24,7 @@ exports.expectError = function OErrorExpectError (e, expected) {
   expect(e.toString()).to.equal(expected.message)
 
   // stack should start with the default error message formatting
-  expect(e.stack.split('\n')[0], expected.name)
+  expect(e.stack.split('\n')[0]).to.match(new RegExp(`^${expected.name}:`))
 
   // first stack frame should be the function where the error was thrown
   expect(e.stack.split('\n')[1]).to.match(expected.firstFrameRx)


### PR DESCRIPTION
As identified by linter.

I think the assertion should be that the first line of the stack trace starts with the correct name.