### PR TITLE
Improve tagging for a (maybe) null error

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,10 +390,35 @@ return it.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| error | <code>Error</code> | the error to tag |
+| error | <code>Error</code> \| <code>null</code> \| <code>undefined</code> | the error to tag (no-op if missing) |
 | [message] | <code>string</code> | message with which to tag `error` |
 | [info] | <code>Object</code> | extra data with wich to tag `error` |
 
+**Example** *(An error in a callback)*  
+```js
+function findUser(name, callback) {
+  fs.readFile('/etc/passwd', (err, data) => {
+    if (err) return callback(OError.tag(err, 'failed to read passwd'))
+    // ...
+  })
+}
+```
+**Example** *(A possible error in a callback)*  
+```js
+function cleanup(callback) {
+  fs.unlink('/tmp/scratch', (err) => callback(OError.tag(err)))
+}
+```
+**Example** *(An error with async/await)*  
+```js
+async function cleanup() {
+  try {
+    await fs.promises.unlink('/tmp/scratch')
+  } catch (err) {
+    throw OError.tag(err, 'failed to remove scratch file')
+  }
+}
+```
 <a name="OError.getFullInfo"></a>
 
 ### OError.getFullInfo(error) ⇒ <code>Object</code>

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Light-weight helpers for handling JavaScript Errors in node.js and the browser.
   * [oError.withInfo(info) ⇒ this](#oerrorwithinfoinfo--this)
   * [oError.withCause(cause) ⇒ this](#oerrorwithcausecause--this)
   * [OError.tag(error, [message], [info]) ⇒ Error](#oerrortagerror-message-info--error)
-  * [OError.tagIfExists(error, [message], [info]) ⇒ Error \| null \| undefined](#oerrortagifexistserror-message-info--error--null--undefined)
   * [OError.getFullInfo(error) ⇒ Object](#oerrorgetfullinfoerror--object)
   * [OError.getFullStack(error) ⇒ string](#oerrorgetfullstackerror--string)
 - [References](#references)
@@ -345,7 +344,6 @@ caused by:
         * [.withCause(cause)](#OError+withCause) ⇒ <code>this</code>
     * _static_
         * [.tag(error, [message], [info])](#OError.tag) ⇒ <code>Error</code>
-        * [.tagIfExists(error, [message], [info])](#OError.tagIfExists) ⇒ <code>Error</code> \| <code>null</code> \| <code>undefined</code>
         * [.getFullInfo(error)](#OError.getFullInfo) ⇒ <code>Object</code>
         * [.getFullStack(error)](#OError.getFullStack) ⇒ <code>string</code>
 
@@ -405,6 +403,12 @@ function findUser(name, callback) {
   })
 }
 ```
+**Example** *(A possible error in a callback)*  
+```js
+function cleanup(callback) {
+  fs.unlink('/tmp/scratch', (err) => callback(err && OError.tag(err)))
+}
+```
 **Example** *(An error with async/await)*  
 ```js
 async function cleanup() {
@@ -413,28 +417,6 @@ async function cleanup() {
   } catch (err) {
     throw OError.tag(err, 'failed to remove scratch file')
   }
-}
-```
-<a name="OError.tagIfExists"></a>
-
-### OError.tagIfExists(error, [message], [info]) ⇒ <code>Error</code> \| <code>null</code> \| <code>undefined</code>
-Like [tag](#OError.tag), but if the error is absent, do nothing. This is
-useful if a callback is just passing an error up the chain without
-checking it.
-
-**Kind**: static method of [<code>OError</code>](#OError)  
-**Returns**: <code>Error</code> \| <code>null</code> \| <code>undefined</code> - the modified `error` argument  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| error | <code>Error</code> \| <code>null</code> \| <code>undefined</code> | the error (if any) to tag |
-| [message] | <code>string</code> | message with which to tag `error` |
-| [info] | <code>Object</code> | extra data with wich to tag `error` |
-
-**Example** *(A possible error in a callback)*  
-```js
-function cleanup(callback) {
-  fs.unlink('/tmp/scratch', (err) => callback(OError.tagIfExists(err)))
 }
 ```
 <a name="OError.getFullInfo"></a>

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Light-weight helpers for handling JavaScript Errors in node.js and the browser.
   * [new OError(message, [info], [cause])](#new-oerrormessage-info-cause)
   * [oError.withInfo(info) ⇒ this](#oerrorwithinfoinfo--this)
   * [oError.withCause(cause) ⇒ this](#oerrorwithcausecause--this)
-  * [OError.tag(error, [message], [info]) ⇒ Error](#oerrortagerror-message-info--error)
+  * [OError.tag(error, [message], [info]) ⇒ Error \| null \| undefined](#oerrortagerror-message-info--error--null--undefined)
   * [OError.getFullInfo(error) ⇒ Object](#oerrorgetfullinfoerror--object)
   * [OError.getFullStack(error) ⇒ string](#oerrorgetfullstackerror--string)
 - [References](#references)
@@ -343,7 +343,7 @@ caused by:
         * [.withInfo(info)](#OError+withInfo) ⇒ <code>this</code>
         * [.withCause(cause)](#OError+withCause) ⇒ <code>this</code>
     * _static_
-        * [.tag(error, [message], [info])](#OError.tag) ⇒ <code>Error</code>
+        * [.tag(error, [message], [info])](#OError.tag) ⇒ <code>Error</code> \| <code>null</code> \| <code>undefined</code>
         * [.getFullInfo(error)](#OError.getFullInfo) ⇒ <code>Object</code>
         * [.getFullStack(error)](#OError.getFullStack) ⇒ <code>string</code>
 
@@ -366,7 +366,7 @@ Set the extra info object for this error.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| info | <code>Object</code> \| <code>null</code> \| <code>undefined</code> | extra data to attach to the error |
+| info | <code>Object</code> | extra data to attach to the error |
 
 <a name="OError+withCause"></a>
 
@@ -381,12 +381,12 @@ Wrap the given error, which caused this error.
 
 <a name="OError.tag"></a>
 
-### OError.tag(error, [message], [info]) ⇒ <code>Error</code>
+### OError.tag(error, [message], [info]) ⇒ <code>Error</code> \| <code>null</code> \| <code>undefined</code>
 Tag debugging information onto any error (whether an OError or not) and
 return it.
 
 **Kind**: static method of [<code>OError</code>](#OError)  
-**Returns**: <code>Error</code> - the modified `error` argument  
+**Returns**: <code>Error</code> \| <code>null</code> \| <code>undefined</code> - the modified `error` argument  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Light-weight helpers for handling JavaScript Errors in node.js and the browser.
   * [new OError(message, [info], [cause])](#new-oerrormessage-info-cause)
   * [oError.withInfo(info) ⇒ this](#oerrorwithinfoinfo--this)
   * [oError.withCause(cause) ⇒ this](#oerrorwithcausecause--this)
-  * [OError.tag(error, [message], [info]) ⇒ Error \| null \| undefined](#oerrortagerror-message-info--error--null--undefined)
+  * [OError.tag(error, [message], [info]) ⇒ Error](#oerrortagerror-message-info--error)
+  * [OError.tagIfExists(error, [message], [info]) ⇒ Error \| null \| undefined](#oerrortagifexistserror-message-info--error--null--undefined)
   * [OError.getFullInfo(error) ⇒ Object](#oerrorgetfullinfoerror--object)
   * [OError.getFullStack(error) ⇒ string](#oerrorgetfullstackerror--string)
 - [References](#references)
@@ -343,7 +344,8 @@ caused by:
         * [.withInfo(info)](#OError+withInfo) ⇒ <code>this</code>
         * [.withCause(cause)](#OError+withCause) ⇒ <code>this</code>
     * _static_
-        * [.tag(error, [message], [info])](#OError.tag) ⇒ <code>Error</code> \| <code>null</code> \| <code>undefined</code>
+        * [.tag(error, [message], [info])](#OError.tag) ⇒ <code>Error</code>
+        * [.tagIfExists(error, [message], [info])](#OError.tagIfExists) ⇒ <code>Error</code> \| <code>null</code> \| <code>undefined</code>
         * [.getFullInfo(error)](#OError.getFullInfo) ⇒ <code>Object</code>
         * [.getFullStack(error)](#OError.getFullStack) ⇒ <code>string</code>
 
@@ -381,16 +383,16 @@ Wrap the given error, which caused this error.
 
 <a name="OError.tag"></a>
 
-### OError.tag(error, [message], [info]) ⇒ <code>Error</code> \| <code>null</code> \| <code>undefined</code>
+### OError.tag(error, [message], [info]) ⇒ <code>Error</code>
 Tag debugging information onto any error (whether an OError or not) and
 return it.
 
 **Kind**: static method of [<code>OError</code>](#OError)  
-**Returns**: <code>Error</code> \| <code>null</code> \| <code>undefined</code> - the modified `error` argument  
+**Returns**: <code>Error</code> - the modified `error` argument  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| error | <code>Error</code> \| <code>null</code> \| <code>undefined</code> | the error to tag (no-op if missing) |
+| error | <code>Error</code> | the error to tag |
 | [message] | <code>string</code> | message with which to tag `error` |
 | [info] | <code>Object</code> | extra data with wich to tag `error` |
 
@@ -403,12 +405,6 @@ function findUser(name, callback) {
   })
 }
 ```
-**Example** *(A possible error in a callback)*  
-```js
-function cleanup(callback) {
-  fs.unlink('/tmp/scratch', (err) => callback(OError.tag(err)))
-}
-```
 **Example** *(An error with async/await)*  
 ```js
 async function cleanup() {
@@ -417,6 +413,28 @@ async function cleanup() {
   } catch (err) {
     throw OError.tag(err, 'failed to remove scratch file')
   }
+}
+```
+<a name="OError.tagIfExists"></a>
+
+### OError.tagIfExists(error, [message], [info]) ⇒ <code>Error</code> \| <code>null</code> \| <code>undefined</code>
+Like [tag](#OError.tag), but if the error is absent, do nothing. This is
+useful if a callback is just passing an error up the chain without
+checking it.
+
+**Kind**: static method of [<code>OError</code>](#OError)  
+**Returns**: <code>Error</code> \| <code>null</code> \| <code>undefined</code> - the modified `error` argument  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| error | <code>Error</code> \| <code>null</code> \| <code>undefined</code> | the error (if any) to tag |
+| [message] | <code>string</code> | message with which to tag `error` |
+| [info] | <code>Object</code> | extra data with wich to tag `error` |
+
+**Example** *(A possible error in a callback)*  
+```js
+function cleanup(callback) {
+  fs.unlink('/tmp/scratch', (err) => callback(OError.tagIfExists(err)))
 }
 ```
 <a name="OError.getFullInfo"></a>

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,11 @@ declare class OError extends Error {
      *   })
      * }
      *
+     * @example <caption>A possible error in a callback</caption>
+     * function cleanup(callback) {
+     *   fs.unlink('/tmp/scratch', (err) => callback(err && OError.tag(err)))
+     * }
+     *
      * @example <caption>An error with async/await</caption>
      * async function cleanup() {
      *   try {
@@ -31,30 +36,6 @@ declare class OError extends Error {
      * @return {Error} the modified `error` argument
      */
     static tag(error: Error, message?: string, info?: any): Error;
-    /**
-     * Like {@link OError.tag}, but if the error is absent, do nothing. This is
-     * useful if a callback is just passing an error up the chain without
-     * checking it.
-     *
-     * @example <caption>A possible error in a callback</caption>
-     * function cleanup(callback) {
-     *   fs.unlink('/tmp/scratch', (err) => callback(OError.tagIfExists(err)))
-     * }
-     *
-     * @param {Error | null | undefined} error the error (if any) to tag
-     * @param {string} [message] message with which to tag `error`
-     * @param {Object} [info] extra data with wich to tag `error`
-     * @return {Error | null | undefined} the modified `error` argument
-     */
-    static tagIfExists(error: Error, message?: string, info?: any): Error;
-    /**
-     * @private
-     * @param {Error} error
-     * @param {string | null | undefined} message
-     * @param {any} info
-     * @param {function} caller
-     */
-    private static _tag;
     /**
      * The merged info from any `tag`s on the given error.
      *

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,29 @@ declare class OError extends Error {
      * Tag debugging information onto any error (whether an OError or not) and
      * return it.
      *
-     * @param {Error} error the error to tag
+     * @example <caption>An error in a callback</caption>
+     * function findUser(name, callback) {
+     *   fs.readFile('/etc/passwd', (err, data) => {
+     *     if (err) return callback(OError.tag(err, 'failed to read passwd'))
+     *     // ...
+     *   })
+     * }
+     *
+     * @example <caption>A possible error in a callback</caption>
+     * function cleanup(callback) {
+     *   fs.unlink('/tmp/scratch', (err) => callback(OError.tag(err)))
+     * }
+     *
+     * @example <caption>An error with async/await</caption>
+     * async function cleanup() {
+     *   try {
+     *     await fs.promises.unlink('/tmp/scratch')
+     *   } catch (err) {
+     *     throw OError.tag(err, 'failed to remove scratch file')
+     *   }
+     * }
+     *
+     * @param {Error | null | undefined} error the error to tag (no-op if missing)
      * @param {string} [message] message with which to tag `error`
      * @param {Object} [info] extra data with wich to tag `error`
      * @return {Error} the modified `error` argument

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,11 +16,6 @@ declare class OError extends Error {
      *   })
      * }
      *
-     * @example <caption>A possible error in a callback</caption>
-     * function cleanup(callback) {
-     *   fs.unlink('/tmp/scratch', (err) => callback(OError.tag(err)))
-     * }
-     *
      * @example <caption>An error with async/await</caption>
      * async function cleanup() {
      *   try {
@@ -30,12 +25,36 @@ declare class OError extends Error {
      *   }
      * }
      *
-     * @param {Error | null | undefined} error the error to tag (no-op if missing)
+     * @param {Error} error the error to tag
+     * @param {string} [message] message with which to tag `error`
+     * @param {Object} [info] extra data with wich to tag `error`
+     * @return {Error} the modified `error` argument
+     */
+    static tag(error: Error, message?: string, info?: any): Error;
+    /**
+     * Like {@link OError.tag}, but if the error is absent, do nothing. This is
+     * useful if a callback is just passing an error up the chain without
+     * checking it.
+     *
+     * @example <caption>A possible error in a callback</caption>
+     * function cleanup(callback) {
+     *   fs.unlink('/tmp/scratch', (err) => callback(OError.tagIfExists(err)))
+     * }
+     *
+     * @param {Error | null | undefined} error the error (if any) to tag
      * @param {string} [message] message with which to tag `error`
      * @param {Object} [info] extra data with wich to tag `error`
      * @return {Error | null | undefined} the modified `error` argument
      */
-    static tag(error: Error, message?: string, info?: any): Error;
+    static tagIfExists(error: Error, message?: string, info?: any): Error;
+    /**
+     * @private
+     * @param {Error} error
+     * @param {string | null | undefined} message
+     * @param {any} info
+     * @param {function} caller
+     */
+    private static _tag;
     /**
      * The merged info from any `tag`s on the given error.
      *

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,7 +33,7 @@ declare class OError extends Error {
      * @param {Error | null | undefined} error the error to tag (no-op if missing)
      * @param {string} [message] message with which to tag `error`
      * @param {Object} [info] extra data with wich to tag `error`
-     * @return {Error} the modified `error` argument
+     * @return {Error | null | undefined} the modified `error` argument
      */
     static tag(error: Error, message?: string, info?: any): Error;
     /**
@@ -61,12 +61,12 @@ declare class OError extends Error {
     constructor(message: string, info?: any, cause?: Error);
     info: any;
     cause: Error;
-    /** @private @type {Array<TaggedError>} */
+    /** @private @type {Array<TaggedError> | undefined} */
     private _oErrorTags;
     /**
      * Set the extra info object for this error.
      *
-     * @param {Object | null | undefined} info extra data to attach to the error
+     * @param {Object} info extra data to attach to the error
      * @return {this}
      */
     withInfo(info: any): OError;

--- a/index.js
+++ b/index.js
@@ -13,15 +13,14 @@ class OError extends Error {
     this.name = this.constructor.name
     if (info) this.info = info
     if (cause) this.cause = cause
-
-    /** @private @type {Array<TaggedError>} */
+    /** @private @type {Array<TaggedError> | undefined} */
     this._oErrorTags // eslint-disable-line
   }
 
   /**
    * Set the extra info object for this error.
    *
-   * @param {Object | null | undefined} info extra data to attach to the error
+   * @param {Object} info extra data to attach to the error
    * @return {this}
    */
   withInfo(info) {
@@ -69,7 +68,7 @@ class OError extends Error {
    * @param {Error | null | undefined} error the error to tag (no-op if missing)
    * @param {string} [message] message with which to tag `error`
    * @param {Object} [info] extra data with wich to tag `error`
-   * @return {Error} the modified `error` argument
+   * @return {Error | null | undefined} the modified `error` argument
    */
   static tag(error, message, info) {
     if (!error) return error
@@ -84,7 +83,7 @@ class OError extends Error {
       tag = /** @type TaggedError */ ({ name: 'TaggedError', message, info })
       Error.captureStackTrace(tag, OError.tag)
     } else {
-      tag = new TaggedError(message, info)
+      tag = new TaggedError(message || '', info)
     }
 
     oError._oErrorTags.push(tag)
@@ -130,7 +129,7 @@ class OError extends Error {
 
     const oError = /** @type{OError} */ (error)
 
-    let stack = oError.stack
+    let stack = oError.stack || '(no stack)'
 
     if (Array.isArray(oError._oErrorTags) && oError._oErrorTags.length) {
       stack += `\n${oError._oErrorTags.map((tag) => tag.stack).join('\n')}`
@@ -153,6 +152,11 @@ class OError extends Error {
  */
 class TaggedError extends OError {}
 
+/**
+ * @private
+ * @param {string} string
+ * @return {string}
+ */
 function indent(string) {
   return string.replace(/^/gm, '    ')
 }

--- a/index.js
+++ b/index.js
@@ -51,6 +51,11 @@ class OError extends Error {
    *   })
    * }
    *
+   * @example <caption>A possible error in a callback</caption>
+   * function cleanup(callback) {
+   *   fs.unlink('/tmp/scratch', (err) => callback(err && OError.tag(err)))
+   * }
+   *
    * @example <caption>An error with async/await</caption>
    * async function cleanup() {
    *   try {
@@ -66,37 +71,6 @@ class OError extends Error {
    * @return {Error} the modified `error` argument
    */
   static tag(error, message, info) {
-    return OError._tag(error, message, info, OError.tag)
-  }
-
-  /**
-   * Like {@link OError.tag}, but if the error is absent, do nothing. This is
-   * useful if a callback is just passing an error up the chain without
-   * checking it.
-   *
-   * @example <caption>A possible error in a callback</caption>
-   * function cleanup(callback) {
-   *   fs.unlink('/tmp/scratch', (err) => callback(OError.tagIfExists(err)))
-   * }
-   *
-   * @param {Error | null | undefined} error the error (if any) to tag
-   * @param {string} [message] message with which to tag `error`
-   * @param {Object} [info] extra data with wich to tag `error`
-   * @return {Error | null | undefined} the modified `error` argument
-   */
-  static tagIfExists(error, message, info) {
-    if (!error) return error
-    return OError._tag(error, message, info, OError.tagIfExists)
-  }
-
-  /**
-   * @private
-   * @param {Error} error
-   * @param {string | null | undefined} message
-   * @param {any} info
-   * @param {function} caller
-   */
-  static _tag(error, message, info, caller) {
     const oError = /** @type{OError} */ (error)
 
     if (!oError._oErrorTags) oError._oErrorTags = []
@@ -105,7 +79,7 @@ class OError extends Error {
     if (Error.captureStackTrace) {
       // Hide this function in the stack trace, and avoid capturing it twice.
       tag = /** @type TaggedError */ ({ name: 'TaggedError', message, info })
-      Error.captureStackTrace(tag, caller)
+      Error.captureStackTrace(tag, OError.tag)
     } else {
       tag = new TaggedError(message || '', info)
     }

--- a/index.js
+++ b/index.js
@@ -51,11 +51,6 @@ class OError extends Error {
    *   })
    * }
    *
-   * @example <caption>A possible error in a callback</caption>
-   * function cleanup(callback) {
-   *   fs.unlink('/tmp/scratch', (err) => callback(OError.tag(err)))
-   * }
-   *
    * @example <caption>An error with async/await</caption>
    * async function cleanup() {
    *   try {
@@ -65,14 +60,43 @@ class OError extends Error {
    *   }
    * }
    *
-   * @param {Error | null | undefined} error the error to tag (no-op if missing)
+   * @param {Error} error the error to tag
+   * @param {string} [message] message with which to tag `error`
+   * @param {Object} [info] extra data with wich to tag `error`
+   * @return {Error} the modified `error` argument
+   */
+  static tag(error, message, info) {
+    return OError._tag(error, message, info, OError.tag)
+  }
+
+  /**
+   * Like {@link OError.tag}, but if the error is absent, do nothing. This is
+   * useful if a callback is just passing an error up the chain without
+   * checking it.
+   *
+   * @example <caption>A possible error in a callback</caption>
+   * function cleanup(callback) {
+   *   fs.unlink('/tmp/scratch', (err) => callback(OError.tagIfExists(err)))
+   * }
+   *
+   * @param {Error | null | undefined} error the error (if any) to tag
    * @param {string} [message] message with which to tag `error`
    * @param {Object} [info] extra data with wich to tag `error`
    * @return {Error | null | undefined} the modified `error` argument
    */
-  static tag(error, message, info) {
+  static tagIfExists(error, message, info) {
     if (!error) return error
+    return OError._tag(error, message, info, OError.tagIfExists)
+  }
 
+  /**
+   * @private
+   * @param {Error} error
+   * @param {string | null | undefined} message
+   * @param {any} info
+   * @param {function} caller
+   */
+  static _tag(error, message, info, caller) {
     const oError = /** @type{OError} */ (error)
 
     if (!oError._oErrorTags) oError._oErrorTags = []
@@ -81,7 +105,7 @@ class OError extends Error {
     if (Error.captureStackTrace) {
       // Hide this function in the stack trace, and avoid capturing it twice.
       tag = /** @type TaggedError */ ({ name: 'TaggedError', message, info })
-      Error.captureStackTrace(tag, OError.tag)
+      Error.captureStackTrace(tag, caller)
     } else {
       tag = new TaggedError(message || '', info)
     }

--- a/index.js
+++ b/index.js
@@ -44,12 +44,36 @@ class OError extends Error {
    * Tag debugging information onto any error (whether an OError or not) and
    * return it.
    *
-   * @param {Error} error the error to tag
+   * @example <caption>An error in a callback</caption>
+   * function findUser(name, callback) {
+   *   fs.readFile('/etc/passwd', (err, data) => {
+   *     if (err) return callback(OError.tag(err, 'failed to read passwd'))
+   *     // ...
+   *   })
+   * }
+   *
+   * @example <caption>A possible error in a callback</caption>
+   * function cleanup(callback) {
+   *   fs.unlink('/tmp/scratch', (err) => callback(OError.tag(err)))
+   * }
+   *
+   * @example <caption>An error with async/await</caption>
+   * async function cleanup() {
+   *   try {
+   *     await fs.promises.unlink('/tmp/scratch')
+   *   } catch (err) {
+   *     throw OError.tag(err, 'failed to remove scratch file')
+   *   }
+   * }
+   *
+   * @param {Error | null | undefined} error the error to tag (no-op if missing)
    * @param {string} [message] message with which to tag `error`
    * @param {Object} [info] extra data with wich to tag `error`
    * @return {Error} the modified `error` argument
    */
   static tag(error, message, info) {
+    if (!error) return error
+
     const oError = /** @type{OError} */ (error)
 
     if (!oError._oErrorTags) oError._oErrorTags = []

--- a/package-lock.json
+++ b/package-lock.json
@@ -317,6 +317,12 @@
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
     },
+    "@types/chai": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.12.tgz",
+      "integrity": "sha512-aN5IAC8QNtSUdQzxu7lGBgYAOuU1tmRU4c9dIq5OKGf/SBVjXo+ffM2wEjudAWbgpOhy60nLoAGH1xm8fpCKFQ==",
+      "dev": true
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "update-readme": "doc/update-readme.js",
     "test": "mocha",
     "test:coverage": "nyc --reporter=lcov --reporter=text-summary npm run test",
-    "typecheck": "tsc --allowJs --checkJs --noEmit --moduleResolution node --target ES6 *.js test/**/*.js",
+    "typecheck": "tsc --allowJs --checkJs --noEmit --moduleResolution node --strict --target ES6 *.js test/**/*.js",
     "declaration:build": "rm -f index.d.ts && tsc --allowJs --declaration --emitDeclarationOnly --moduleResolution node --target ES6 index.js",
     "declaration:check": "git diff --exit-code -- index.d.ts",
     "prepublishOnly": "npm run --silent declaration:build && npm run --silent declaration:check"
@@ -31,6 +31,7 @@
   "license": "MIT",
   "repository": "github:overleaf/o-error",
   "devDependencies": {
+    "@types/chai": "^4.2.12",
     "@types/node": "^13.13.2",
     "chai": "^3.3.0",
     "eslint": "^6.8.0",

--- a/test/o-error-util.test.js
+++ b/test/o-error-util.test.js
@@ -151,7 +151,7 @@ describe('OError.tag', function () {
   })
 
   it('is not included in the stack trace if using capture', function () {
-    if (!Error.captureStackTrace) return
+    if (!Error.captureStackTrace) return this.skip()
     const err = new Error('test error')
     OError.tag(err, 'test message')
     const stack = OError.getFullStack(err)

--- a/test/o-error-util.test.js
+++ b/test/o-error-util.test.js
@@ -150,10 +150,40 @@ describe('OError.tag', function () {
     })
   })
 
+  it('is not included in the stack trace if using capture', function () {
+    if (!Error.captureStackTrace) return
+    const err = new Error('test error')
+    OError.tag(err, 'test message')
+    const stack = OError.getFullStack(err)
+    expect(stack).to.match(/TaggedError: test message\n\s+at/)
+    expect(stack).to.not.match(/TaggedError: test message\n\s+at _tag/)
+  })
+})
+
+describe('OError.tagIfExists', function () {
+  it('tags an error', function () {
+    const err = new Error('test error')
+    expect(OError.tagIfExists(err, 'test message', { a: 1 })).to.eql(err)
+    expectFullStackWithoutStackFramesToEqual(err, [
+      'Error: test error',
+      'TaggedError: test message',
+    ])
+    expect(OError.getFullInfo(err)).to.eql({ a: 1 })
+  })
+
   it('does nothing on an undefined or null error', function () {
-    expect(OError.tag(undefined)).to.be.undefined
-    expect(OError.tag(null)).to.be.null
-    expect(OError.tag(null, 'ignored message', { info: 1 })).to.be.null
+    expect(OError.tagIfExists(undefined)).to.be.undefined
+    expect(OError.tagIfExists(null)).to.be.null
+    expect(OError.tagIfExists(null, 'ignored message', { info: 1 })).to.be.null
+  })
+
+  it('is not included in the stack trace if using capture', function () {
+    if (!Error.captureStackTrace) return
+    const err = new Error('test error')
+    OError.tagIfExists(err, 'test message')
+    const stack = OError.getFullStack(err)
+    expect(stack).to.match(/TaggedError: test message\n\s+at/)
+    expect(stack).to.not.match(/TaggedError: test message\n\s+at _tag/)
   })
 })
 

--- a/test/o-error-util.test.js
+++ b/test/o-error-util.test.js
@@ -156,34 +156,7 @@ describe('OError.tag', function () {
     OError.tag(err, 'test message')
     const stack = OError.getFullStack(err)
     expect(stack).to.match(/TaggedError: test message\n\s+at/)
-    expect(stack).to.not.match(/TaggedError: test message\n\s+at _tag/)
-  })
-})
-
-describe('OError.tagIfExists', function () {
-  it('tags an error', function () {
-    const err = new Error('test error')
-    expect(OError.tagIfExists(err, 'test message', { a: 1 })).to.eql(err)
-    expectFullStackWithoutStackFramesToEqual(err, [
-      'Error: test error',
-      'TaggedError: test message',
-    ])
-    expect(OError.getFullInfo(err)).to.eql({ a: 1 })
-  })
-
-  it('does nothing on an undefined or null error', function () {
-    expect(OError.tagIfExists(undefined)).to.be.undefined
-    expect(OError.tagIfExists(null)).to.be.null
-    expect(OError.tagIfExists(null, 'ignored message', { info: 1 })).to.be.null
-  })
-
-  it('is not included in the stack trace if using capture', function () {
-    if (!Error.captureStackTrace) return
-    const err = new Error('test error')
-    OError.tagIfExists(err, 'test message')
-    const stack = OError.getFullStack(err)
-    expect(stack).to.match(/TaggedError: test message\n\s+at/)
-    expect(stack).to.not.match(/TaggedError: test message\n\s+at _tag/)
+    expect(stack).to.not.match(/TaggedError: test message\n\s+at [\w.]*tag/)
   })
 })
 

--- a/test/o-error-util.test.js
+++ b/test/o-error-util.test.js
@@ -149,6 +149,12 @@ describe('OError.tag', function () {
       expect.fail('should have yielded an error')
     })
   })
+
+  it('does nothing on an undefined or null error', function () {
+    expect(OError.tag(undefined)).to.be.undefined
+    expect(OError.tag(null)).to.be.null
+    expect(OError.tag(null, 'ignored message', { info: 1 })).to.be.null
+  })
 })
 
 describe('OError.getFullInfo', function () {

--- a/test/o-error-util.test.js
+++ b/test/o-error-util.test.js
@@ -188,6 +188,10 @@ describe('OError.tagIfExists', function () {
 })
 
 describe('OError.getFullInfo', function () {
+  it('works when given null', function () {
+    expect(OError.getFullInfo(null)).to.deep.equal({})
+  })
+
   it('works on a normal error', function () {
     const err = new Error('foo')
     expect(OError.getFullInfo(err)).to.deep.equal({})
@@ -229,6 +233,10 @@ describe('OError.getFullInfo', function () {
 })
 
 describe('OError.getFullStack', function () {
+  it('works when given null', function () {
+    expect(OError.getFullStack(null)).to.equal('')
+  })
+
   it('works on a normal error', function () {
     const err = new Error('foo')
     const fullStack = OError.getFullStack(err)

--- a/test/o-error-util.test.js
+++ b/test/o-error-util.test.js
@@ -158,6 +158,28 @@ describe('OError.tag', function () {
     expect(stack).to.match(/TaggedError: test message\n\s+at/)
     expect(stack).to.not.match(/TaggedError: test message\n\s+at [\w.]*tag/)
   })
+
+  describe('without Error.captureStackTrace', function () {
+    /* eslint-disable mocha/no-hooks-for-single-case */
+    before(function () {
+      this.originalCaptureStackTrace = Error.captureStackTrace
+      Error.captureStackTrace = null
+    })
+    after(function () {
+      Error.captureStackTrace = this.originalCaptureStackTrace
+    })
+
+    it('still captures a stack trace, albeit including itself', function () {
+      const err = new Error('test error')
+      OError.tag(err, 'test message')
+      expectFullStackWithoutStackFramesToEqual(err, [
+        'Error: test error',
+        'TaggedError: test message',
+      ])
+      const stack = OError.getFullStack(err)
+      expect(stack).to.match(/TaggedError: test message\n\s+at [\w.]*tag/)
+    })
+  })
 })
 
 describe('OError.getFullInfo', function () {

--- a/test/support/index.js
+++ b/test/support/index.js
@@ -2,6 +2,10 @@ const { expect } = require('chai')
 
 const OError = require('../..')
 
+/**
+ * @param {Error} e
+ * @param {any} expected
+ */
 exports.expectError = function OErrorExpectError(e, expected) {
   expect(
     e.name,
@@ -23,24 +27,28 @@ exports.expectError = function OErrorExpectError(e, expected) {
     'error should be recognised by util.types.isNativeError'
   ).to.be.true
 
-  expect(e.stack, 'error should have a stack trace').to.be.truthy
-
   expect(
     e.toString(),
     'toString should return the default error message formatting'
   ).to.equal(expected.message)
 
+  expect(e.stack, 'error should have a stack trace').to.not.be.empty
+
   expect(
-    e.stack.split('\n')[0],
+    /** @type {string} */ (e.stack).split('\n')[0],
     'stack should start with the default error message formatting'
   ).to.match(new RegExp(`^${expected.name}:`))
 
   expect(
-    e.stack.split('\n')[1],
+    /** @type {string} */ (e.stack).split('\n')[1],
     'first stack frame should be the function where the error was thrown'
   ).to.match(expected.firstFrameRx)
 }
 
+/**
+ * @param {Error} error
+ * @param {String[]} expected
+ */
 exports.expectFullStackWithoutStackFramesToEqual = function (error, expected) {
   const fullStack = OError.getFullStack(error)
   const fullStackWithoutFrames = fullStack


### PR DESCRIPTION
When trying to add some error tagging, I noticed that fairly often a callback is just passing a possible error up the chain, e.g.
```js
function foo(callback) {
  bar((err, ignoredResult) => callback(err))
}
// or just
function foo(callback) {
  bar((err) => callback(err))
}
// or, if we are OK with passing back the ignored result, just
function foo(callback) {
  bar(callback)
}
```

At the moment, tagging the error in those cases is quite cumbersome, because it might be (probably will be) null, and `OError.tag` can't handle a null. So the one-liner has to turn into a full error check:
```js
function foo(callback) {
  bar((err, ignoredResult) => {
    if (err) return callback(OError.tag(err))
    callback()
   }
}
```

If `OError.tag` is a no-op when the error is null, then we can write
```js
function foo(callback) {
  bar((err) => callback(OError.tag(err)))
}
```
instead, which is a bit shorter.

I wondered about instead / also providing some sort of callback wrapper, along the lines of
```js
OError.tagErrback = (callback, message, info) => {
  return (err, ...args) => {
    if (err) {
      callback(OError.tag(err, message, info))
    } else {
      callback(null, ...args)
    }
  }
}

// usage:
function foo(callback) {
  bar(OError.tagErrback(callback))
}
// or
function foo(callback) {
  bar(OError.tagErrback(callback, 'failed to bar'))
}
```
but that seems a bit magical and hard to name, and we're trying to move toward async/await anyway, so I thought maybe this simple change to ignore a null `err` would suffice.

I added two more unrelated examples while updating the docs for this case (they get copied from the jsdoc to the readme and the .d.ts).

This could go into a minor release.