### PR TITLE
Add a limit on the number of tags, OError.maxTags

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,32 @@ export = OError;
  */
 declare class OError extends Error {
     /**
+     * @param {string} message as for built-in Error
+     * @param {Object} [info] extra data to attach to the error
+     * @param {Error} [cause] the internal error that caused this error
+     */
+    constructor(message: string, info?: any, cause?: Error);
+    info: any;
+    cause: Error;
+    /** @private @type {Array<TaggedError> | undefined} */
+    private _oErrorTags;
+    /**
+     * Set the extra info object for this error.
+     *
+     * @param {Object} info extra data to attach to the error
+     * @return {this}
+     */
+    withInfo(info: any): OError;
+    /**
+     * Wrap the given error, which caused this error.
+     *
+     * @param {Error} cause the internal error that caused this error
+     * @return {this}
+     */
+    withCause(cause: Error): OError;
+}
+declare namespace OError {
+    /**
      * Tag debugging information onto any error (whether an OError or not) and
      * return it.
      *
@@ -35,7 +61,7 @@ declare class OError extends Error {
      * @param {Object} [info] extra data with wich to tag `error`
      * @return {Error} the modified `error` argument
      */
-    static tag(error: Error, message?: string, info?: any): Error;
+    export function tag(error: Error, message?: string, info?: any): Error;
     /**
      * The merged info from any `tag`s on the given error.
      *
@@ -44,7 +70,7 @@ declare class OError extends Error {
      * @param {Error | null | undefined} error any errror (may or may not be an `OError`)
      * @return {Object}
      */
-    static getFullInfo(error: Error): any;
+    export function getFullInfo(error: Error): any;
     /**
      * Return the `stack` property from `error`, including the `stack`s for any
      * tagged errors added with `OError.tag` and for any `cause`s.
@@ -52,29 +78,6 @@ declare class OError extends Error {
      * @param {Error | null | undefined} error any error (may or may not be an `OError`)
      * @return {string}
      */
-    static getFullStack(error: Error): string;
-    /**
-     * @param {string} message as for built-in Error
-     * @param {Object} [info] extra data to attach to the error
-     * @param {Error} [cause] the internal error that caused this error
-     */
-    constructor(message: string, info?: any, cause?: Error);
-    info: any;
-    cause: Error;
-    /** @private @type {Array<TaggedError> | undefined} */
-    private _oErrorTags;
-    /**
-     * Set the extra info object for this error.
-     *
-     * @param {Object} info extra data to attach to the error
-     * @return {this}
-     */
-    withInfo(info: any): OError;
-    /**
-     * Wrap the given error, which caused this error.
-     *
-     * @param {Error} cause the internal error that caused this error
-     * @return {this}
-     */
-    withCause(cause: Error): OError;
+    export function getFullStack(error: Error): string;
+    export const maxTags: Number;
 }

--- a/index.js
+++ b/index.js
@@ -84,6 +84,14 @@ class OError extends Error {
       tag = new TaggedError(message || '', info)
     }
 
+    if (oError._oErrorTags.length >= OError.maxTags) {
+      // Preserve the first tag and add an indicator that we dropped some tags.
+      if (oError._oErrorTags.includes(DROPPED_TAGS_ERROR)) {
+        oError._oErrorTags.splice(2, 1)
+      } else {
+        oError._oErrorTags[1] = DROPPED_TAGS_ERROR
+      }
+    }
     oError._oErrorTags.push(tag)
 
     return error
@@ -143,12 +151,26 @@ class OError extends Error {
 }
 
 /**
+ * Maximum number of tags to apply to any one error instance. This is to avoid
+ * a resource leak in the (hopefully unlikely) case that a singleton error
+ * instance is returned to many callbacks. If tags have been dropped, the full
+ * stack trace will include a placeholder tag `... dropped tags`.
+ *
+ * Defaults to 100. Must be at least 1.
+ *
+ * @type {Number}
+ */
+OError.maxTags = 100
+
+/**
  * Used to record a stack trace every time we tag info onto an Error.
  *
  * @private
  * @extends OError
  */
 class TaggedError extends OError {}
+
+const DROPPED_TAGS_ERROR = new TaggedError('... dropped tags')
 
 /**
  * @private

--- a/index.js
+++ b/index.js
@@ -170,7 +170,11 @@ OError.maxTags = 100
  */
 class TaggedError extends OError {}
 
-const DROPPED_TAGS_ERROR = new TaggedError('... dropped tags')
+const DROPPED_TAGS_ERROR = /** @type{TaggedError} */ ({
+  name: 'TaggedError',
+  message: '... dropped tags',
+  stack: 'TaggedError: ... dropped tags',
+})
 
 /**
  * @private

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ class OError extends Error {
 
     if (oError._oErrorTags.length >= OError.maxTags) {
       // Preserve the first tag and add an indicator that we dropped some tags.
-      if (oError._oErrorTags.includes(DROPPED_TAGS_ERROR)) {
+      if (oError._oErrorTags[1] === DROPPED_TAGS_ERROR) {
         oError._oErrorTags.splice(2, 1)
       } else {
         oError._oErrorTags[1] = DROPPED_TAGS_ERROR

--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
     "index.d.ts"
   ],
   "scripts": {
+    "declaration:build": "rm -f index.d.ts && tsc --allowJs --declaration --emitDeclarationOnly --moduleResolution node --target ES6 index.js",
+    "declaration:check": "git diff --exit-code -- index.d.ts",
     "lint": "eslint .",
-    "update-readme": "doc/update-readme.js",
+    "prepublishOnly": "npm run --silent declaration:build && npm run --silent declaration:check",
     "test": "mocha",
     "test:coverage": "nyc --reporter=lcov --reporter=text-summary npm run test",
     "typecheck": "tsc --allowJs --checkJs --noEmit --moduleResolution node --strict --target ES6 *.js test/**/*.js",
-    "declaration:build": "rm -f index.d.ts && tsc --allowJs --declaration --emitDeclarationOnly --moduleResolution node --target ES6 index.js",
-    "declaration:check": "git diff --exit-code -- index.d.ts",
-    "prepublishOnly": "npm run --silent declaration:build && npm run --silent declaration:check"
+    "update-readme": "doc/update-readme.js"
   },
   "author": "Overleaf (https://www.overleaf.com)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "index.d.ts"
   ],
   "scripts": {
+    "build": "npm run --silent typecheck && npm run --silent test && npm run --silent declaration:build && npm run --silent update-readme",
     "declaration:build": "rm -f index.d.ts && tsc --allowJs --declaration --emitDeclarationOnly --moduleResolution node --target ES6 index.js",
     "declaration:check": "git diff --exit-code -- index.d.ts",
     "lint": "eslint .",

--- a/test/o-error-util.test.js
+++ b/test/o-error-util.test.js
@@ -180,6 +180,91 @@ describe('OError.tag', function () {
       expect(stack).to.match(/TaggedError: test message\n\s+at [\w.]*tag/)
     })
   })
+
+  describe('with limit on the number of tags', function () {
+    before(function () {
+      this.originalMaxTags = OError.maxTags
+      OError.maxTags = 3
+    })
+    after(function () {
+      OError.maxTags = this.originalMaxTags
+    })
+
+    it('should not tag more than that', function () {
+      const err = new Error('test error')
+      OError.tag(err, 'test message 1')
+      OError.tag(err, 'test message 2')
+      OError.tag(err, 'test message 3')
+      OError.tag(err, 'test message 4')
+      OError.tag(err, 'test message 5')
+      expectFullStackWithoutStackFramesToEqual(err, [
+        'Error: test error',
+        'TaggedError: test message 1',
+        'TaggedError: ... dropped tags',
+        'TaggedError: test message 4',
+        'TaggedError: test message 5',
+      ])
+    })
+
+    it('should handle deep recursion', async function () {
+      async function recursiveAdd(n) {
+        try {
+          if (n === 0) throw new Error('deep error')
+          const result = await recursiveAdd(n - 1)
+          return result + 1
+        } catch (err) {
+          throw OError.tag(err, `at level ${n}`)
+        }
+      }
+      try {
+        await recursiveAdd(10)
+      } catch (err) {
+        expectFullStackWithoutStackFramesToEqual(err, [
+          'Error: deep error',
+          'TaggedError: at level 0',
+          'TaggedError: ... dropped tags',
+          'TaggedError: at level 9',
+          'TaggedError: at level 10',
+        ])
+      }
+    })
+
+    it('should handle a singleton error', function (done) {
+      const err = new Error('singleton error')
+      function endpoint(callback) {
+        helper((err) => callback(err && OError.tag(err, 'in endpoint')))
+      }
+      function helper(callback) {
+        libraryFunction((err) => {
+          if (err) {
+            OError.tag(err, 'in helper')
+            process.nextTick(function () {
+              callback(err)
+            })
+          }
+        })
+      }
+      function libraryFunction(callback) {
+        process.nextTick(function () {
+          callback(err)
+        })
+      }
+
+      endpoint(() => {
+        endpoint((err) => {
+          expect(err).to.exist
+          expectFullStackWithoutStackFramesToEqual(err, [
+            'Error: singleton error',
+            'TaggedError: in helper',
+            'TaggedError: ... dropped tags',
+            'TaggedError: in helper',
+            'TaggedError: in endpoint',
+          ])
+          done()
+        })
+      })
+    })
+  })
 })
 
 describe('OError.getFullInfo', function () {

--- a/test/o-error-util.test.js
+++ b/test/o-error-util.test.js
@@ -235,19 +235,10 @@ describe('OError.tag', function () {
         helper((err) => callback(err && OError.tag(err, 'in endpoint')))
       }
       function helper(callback) {
-        libraryFunction((err) => {
-          if (err) {
-            OError.tag(err, 'in helper')
-            process.nextTick(function () {
-              callback(err)
-            })
-          }
-        })
+        libraryFunction((err) => callback(err && OError.tag(err, 'in helper')))
       }
       function libraryFunction(callback) {
-        process.nextTick(function () {
-          callback(err)
-        })
+        callback(err)
       }
 
       endpoint(() => {


### PR DESCRIPTION
I've added the explanation to the README. Basically: we want a limit on the number of tags.

Notes:
- Adding the static property changed the typescript declaration quite a lot... but I think it is equivalent.
- We discussed whether to drop from the start (deepest) or the end (shallowest) of the tags list and in the end settled on keeping the first tag and then dropping from the start after that. Our rationale was that the first tag is important for finding where in our code we called a library that generated an error, and the last tags are important for figuring out which endpoint caused an error.
   - That said, we set `maxTags` quite high, so hopefully we will never get into a situation where we dropped useful tags, and it may be slightly overcomplicated.
   - And it means that there's a bit of a potential resource leak if there is a singleton error, because the first tag will stay in its tags list forever, as opposed to a eventually cycling through. But, it is at least a bounded leak.
- We thought it important to add some indicator that tags had been dropped, so we added in a placeholder tag for that (using, funnily enough, a singleton error instance).
- Some unrelated changes: I alphabetised the package scripts and added a 'build' script that I've found useful for updating the API documentation in the README and declarations etc.

Paired on this with @das7pad .