### PR TITLE
[OError] getFullInfo returns the error context of nested causes

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ async function cleanup() {
 <a name="OError.getFullInfo"></a>
 
 ### OError.getFullInfo(error) ⇒ <code>Object</code>
-The merged info from any `tag`s on the given error.
+The merged info from any `tag`s and causes on the given error.
 
 If an info property is repeated, the last one wins.
 
@@ -450,7 +450,7 @@ If an info property is repeated, the last one wins.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| error | <code>Error</code> \| <code>null</code> \| <code>undefined</code> | any errror (may or may not be an `OError`) |
+| error | <code>Error</code> \| <code>null</code> \| <code>undefined</code> | any error (may or may not be an `OError`) |
 
 <a name="OError.getFullStack"></a>
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Light-weight helpers for handling JavaScript Errors in node.js and the browser.
   * [OError.maxTags : Number](#oerrormaxtags--number)
   * [OError.tag(error, [message], [info]) ⇒ Error](#oerrortagerror-message-info--error)
   * [OError.getFullInfo(error) ⇒ Object](#oerrorgetfullinfoerror--object)
-  * [OError.getFullInfoIncludeCause(error) ⇒ Object](#oerrorgetfullinfoincludecauseerror--object)
   * [OError.getFullStack(error) ⇒ string](#oerrorgetfullstackerror--string)
 - [References](#references)
 
@@ -355,7 +354,6 @@ caused by:
         * [.maxTags](#OError.maxTags) : <code>Number</code>
         * [.tag(error, [message], [info])](#OError.tag) ⇒ <code>Error</code>
         * [.getFullInfo(error)](#OError.getFullInfo) ⇒ <code>Object</code>
-        * [.getFullInfoIncludeCause(error)](#OError.getFullInfoIncludeCause) ⇒ <code>Object</code>
         * [.getFullStack(error)](#OError.getFullStack) ⇒ <code>string</code>
 
 <a name="new_OError_new"></a>
@@ -453,19 +451,6 @@ If an info property is repeated, the last one wins.
 | Param | Type | Description |
 | --- | --- | --- |
 | error | <code>Error</code> \| <code>null</code> \| <code>undefined</code> | any errror (may or may not be an `OError`) |
-
-<a name="OError.getFullInfoIncludeCause"></a>
-
-### OError.getFullInfoIncludeCause(error) ⇒ <code>Object</code>
-The merged info from any `tag`s and nested causes on the given error.
-
-See also `OError.getFullInfo`.
-
-**Kind**: static method of [<code>OError</code>](#OError)  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| error | <code>Error</code> \| <code>null</code> \| <code>undefined</code> | any error (may or may not be an `OError`) |
 
 <a name="OError.getFullStack"></a>
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Light-weight helpers for handling JavaScript Errors in node.js and the browser.
   * [OError.maxTags : Number](#oerrormaxtags--number)
   * [OError.tag(error, [message], [info]) ⇒ Error](#oerrortagerror-message-info--error)
   * [OError.getFullInfo(error) ⇒ Object](#oerrorgetfullinfoerror--object)
+  * [OError.getFullInfoIncludeCause(error) ⇒ Object](#oerrorgetfullinfoincludecauseerror--object)
   * [OError.getFullStack(error) ⇒ string](#oerrorgetfullstackerror--string)
 - [References](#references)
 
@@ -354,6 +355,7 @@ caused by:
         * [.maxTags](#OError.maxTags) : <code>Number</code>
         * [.tag(error, [message], [info])](#OError.tag) ⇒ <code>Error</code>
         * [.getFullInfo(error)](#OError.getFullInfo) ⇒ <code>Object</code>
+        * [.getFullInfoIncludeCause(error)](#OError.getFullInfoIncludeCause) ⇒ <code>Object</code>
         * [.getFullStack(error)](#OError.getFullStack) ⇒ <code>string</code>
 
 <a name="new_OError_new"></a>
@@ -451,6 +453,19 @@ If an info property is repeated, the last one wins.
 | Param | Type | Description |
 | --- | --- | --- |
 | error | <code>Error</code> \| <code>null</code> \| <code>undefined</code> | any errror (may or may not be an `OError`) |
+
+<a name="OError.getFullInfoIncludeCause"></a>
+
+### OError.getFullInfoIncludeCause(error) ⇒ <code>Object</code>
+The merged info from any `tag`s and nested causes on the given error.
+
+See also `OError.getFullInfo`.
+
+**Kind**: static method of [<code>OError</code>](#OError)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| error | <code>Error</code> \| <code>null</code> \| <code>undefined</code> | any error (may or may not be an `OError`) |
 
 <a name="OError.getFullStack"></a>
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -63,11 +63,11 @@ declare namespace OError {
      */
     export function tag(error: Error, message?: string, info?: any): Error;
     /**
-     * The merged info from any `tag`s on the given error.
+     * The merged info from any `tag`s and causes on the given error.
      *
      * If an info property is repeated, the last one wins.
      *
-     * @param {Error | null | undefined} error any errror (may or may not be an `OError`)
+     * @param {Error | null | undefined} error any error (may or may not be an `OError`)
      * @return {Object}
      */
     export function getFullInfo(error: Error): any;

--- a/index.d.ts
+++ b/index.d.ts
@@ -72,6 +72,15 @@ declare namespace OError {
      */
     export function getFullInfo(error: Error): any;
     /**
+     * The merged info from any `tag`s and nested causes on the given error.
+     *
+     * See also `OError.getFullInfo`.
+     *
+     * @param {Error | null | undefined} error any error (may or may not be an `OError`)
+     * @return {Object}
+     */
+    export function getFullInfoIncludeCause(error: Error): any;
+    /**
      * Return the `stack` property from `error`, including the `stack`s for any
      * tagged errors added with `OError.tag` and for any `cause`s.
      *

--- a/index.d.ts
+++ b/index.d.ts
@@ -72,15 +72,6 @@ declare namespace OError {
      */
     export function getFullInfo(error: Error): any;
     /**
-     * The merged info from any `tag`s and nested causes on the given error.
-     *
-     * See also `OError.getFullInfo`.
-     *
-     * @param {Error | null | undefined} error any error (may or may not be an `OError`)
-     * @return {Object}
-     */
-    export function getFullInfoIncludeCause(error: Error): any;
-    /**
      * Return the `stack` property from `error`, including the `stack`s for any
      * tagged errors added with `OError.tag` and for any `cause`s.
      *

--- a/index.js
+++ b/index.js
@@ -124,6 +124,25 @@ class OError extends Error {
   }
 
   /**
+   * The merged info from any `tag`s and nested causes on the given error.
+   *
+   * See also `OError.getFullInfo`.
+   *
+   * @param {Error | null | undefined} error any error (may or may not be an `OError`)
+   * @return {Object}
+   */
+  static getFullInfoIncludeCause(error) {
+    const info = OError.getFullInfo(error)
+    if (!error) return info
+
+    const oError = /** @type{OError} */ (error)
+    if (oError.cause) {
+      Object.assign(info, OError.getFullInfoIncludeCause(oError.cause))
+    }
+    return info
+  }
+
+  /**
    * Return the `stack` property from `error`, including the `stack`s for any
    * tagged errors added with `OError.tag` and for any `cause`s.
    *

--- a/index.js
+++ b/index.js
@@ -98,11 +98,11 @@ class OError extends Error {
   }
 
   /**
-   * The merged info from any `tag`s on the given error.
+   * The merged info from any `tag`s and causes on the given error.
    *
    * If an info property is repeated, the last one wins.
    *
-   * @param {Error | null | undefined} error any errror (may or may not be an `OError`)
+   * @param {Error | null | undefined} error any error (may or may not be an `OError`)
    * @return {Object}
    */
   static getFullInfo(error) {
@@ -113,6 +113,10 @@ class OError extends Error {
     const oError = /** @type{OError} */ (error)
 
     if (typeof oError.info === 'object') Object.assign(info, oError.info)
+
+    if (oError.cause) {
+      Object.assign(info, OError.getFullInfo(oError.cause))
+    }
 
     if (oError._oErrorTags) {
       for (const tag of oError._oErrorTags) {

--- a/index.js
+++ b/index.js
@@ -112,11 +112,9 @@ class OError extends Error {
 
     const oError = /** @type{OError} */ (error)
 
-    if (typeof oError.info === 'object') Object.assign(info, oError.info)
+    if (oError.cause) Object.assign(info, OError.getFullInfo(oError.cause))
 
-    if (oError.cause) {
-      Object.assign(info, OError.getFullInfo(oError.cause))
-    }
+    if (typeof oError.info === 'object') Object.assign(info, oError.info)
 
     if (oError._oErrorTags) {
       for (const tag of oError._oErrorTags) {

--- a/index.js
+++ b/index.js
@@ -124,25 +124,6 @@ class OError extends Error {
   }
 
   /**
-   * The merged info from any `tag`s and nested causes on the given error.
-   *
-   * See also `OError.getFullInfo`.
-   *
-   * @param {Error | null | undefined} error any error (may or may not be an `OError`)
-   * @return {Object}
-   */
-  static getFullInfoIncludeCause(error) {
-    const info = OError.getFullInfo(error)
-    if (!error) return info
-
-    const oError = /** @type{OError} */ (error)
-    if (oError.cause) {
-      Object.assign(info, OError.getFullInfoIncludeCause(oError.cause))
-    }
-    return info
-  }
-
-  /**
    * Return the `stack` property from `error`, including the `stack`s for any
    * tagged errors added with `OError.tag` and for any `cause`s.
    *

--- a/test/o-error-util.test.js
+++ b/test/o-error-util.test.js
@@ -303,65 +303,6 @@ describe('OError.getFullInfo', function () {
   })
 })
 
-describe('OError.getFullInfoIncludeCause', function () {
-  it('works when given null', function () {
-    expect(OError.getFullInfoIncludeCause(null)).to.deep.equal({})
-  })
-
-  it('works on a normal error', function () {
-    const err = new Error('foo')
-    expect(OError.getFullInfoIncludeCause(err)).to.deep.equal({})
-  })
-
-  it('works on an error with tags', function () {
-    const err = OError.tag(new Error('foo'), 'bar', { userId: 123 })
-    expect(OError.getFullInfoIncludeCause(err)).to.deep.equal({ userId: 123 })
-  })
-
-  it('merges info from an error and its tags', function () {
-    const err = new OError('foo').withInfo({ projectId: 456 })
-    OError.tag(err, 'failed to foo', { userId: 123 })
-    expect(OError.getFullInfoIncludeCause(err)).to.deep.equal({
-      projectId: 456,
-      userId: 123,
-    })
-  })
-
-  it('merges info from a cause', function () {
-    const err1 = new Error('foo')
-    const err2 = new Error('bar')
-    err1.cause = err2
-    err2.info = { userId: 123 }
-    expect(OError.getFullInfoIncludeCause(err1)).to.deep.equal({ userId: 123 })
-  })
-
-  it('merges info from a nested cause', function () {
-    const err1 = new Error('foo')
-    const err2 = new Error('bar')
-    const err3 = new Error('bar')
-    err1.cause = err2
-    err2.info = { userId: 123 }
-    err2.cause = err3
-    err3.info = { foo: 42 }
-    expect(OError.getFullInfoIncludeCause(err1)).to.deep.equal({
-      userId: 123,
-      foo: 42,
-    })
-  })
-
-  it('merges info from tags with duplicate keys', function () {
-    const err1 = OError.tag(new Error('foo'), 'bar', { userId: 123 })
-    const err2 = OError.tag(err1, 'bat', { userId: 456 })
-    expect(OError.getFullInfoIncludeCause(err2)).to.deep.equal({ userId: 456 })
-  })
-
-  it('works on an error with .info set to a string', function () {
-    const err = new Error('foo')
-    err.info = 'test'
-    expect(OError.getFullInfoIncludeCause(err)).to.deep.equal({})
-  })
-})
-
 describe('OError.getFullStack', function () {
   it('works when given null', function () {
     expect(OError.getFullStack(null)).to.equal('')

--- a/test/o-error-util.test.js
+++ b/test/o-error-util.test.js
@@ -282,12 +282,26 @@ describe('OError.getFullInfo', function () {
     })
   })
 
-  it('does not merge info from a cause', function () {
+  it('merges info from a cause', function () {
     const err1 = new Error('foo')
     const err2 = new Error('bar')
     err1.cause = err2
     err2.info = { userId: 123 }
-    expect(OError.getFullInfo(err1)).to.deep.equal({})
+    expect(OError.getFullInfo(err1)).to.deep.equal({ userId: 123 })
+  })
+
+  it('merges info from a nested cause', function () {
+    const err1 = new Error('foo')
+    const err2 = new Error('bar')
+    const err3 = new Error('baz')
+    err1.cause = err2
+    err2.info = { userId: 123 }
+    err2.cause = err3
+    err3.info = { foo: 42 }
+    expect(OError.getFullInfo(err1)).to.deep.equal({
+      userId: 123,
+      foo: 42,
+    })
   })
 
   it('merges info from tags with duplicate keys', function () {
@@ -371,8 +385,8 @@ describe('OError.getFullStack', function () {
         '    TaggedError: failed to foo',
       ])
 
-      // The info from the wrapped cause should not leak out.
-      expect(OError.getFullInfo(error)).to.eql({ bat: 1 })
+      // The info from the wrapped cause should be picked up for logging.
+      expect(OError.getFullInfo(error)).to.eql({ bat: 1, foo: 1 })
 
       // But it should still be recorded.
       expect(OError.getFullInfo(error.cause)).to.eql({ foo: 1 })

--- a/test/o-error-util.test.js
+++ b/test/o-error-util.test.js
@@ -304,6 +304,18 @@ describe('OError.getFullInfo', function () {
     })
   })
 
+  it('merges info from cause with duplicate keys', function () {
+    const err1 = new Error('foo')
+    const err2 = new Error('bar')
+    err1.info = { userId: 42, foo: 1337 }
+    err1.cause = err2
+    err2.info = { userId: 1 }
+    expect(OError.getFullInfo(err1)).to.deep.equal({
+      userId: 42,
+      foo: 1337,
+    })
+  })
+
   it('merges info from tags with duplicate keys', function () {
     const err1 = OError.tag(new Error('foo'), 'bar', { userId: 123 })
     const err2 = OError.tag(err1, 'bat', { userId: 456 })

--- a/test/o-error-util.test.js
+++ b/test/o-error-util.test.js
@@ -303,6 +303,65 @@ describe('OError.getFullInfo', function () {
   })
 })
 
+describe('OError.getFullInfoIncludeCause', function () {
+  it('works when given null', function () {
+    expect(OError.getFullInfoIncludeCause(null)).to.deep.equal({})
+  })
+
+  it('works on a normal error', function () {
+    const err = new Error('foo')
+    expect(OError.getFullInfoIncludeCause(err)).to.deep.equal({})
+  })
+
+  it('works on an error with tags', function () {
+    const err = OError.tag(new Error('foo'), 'bar', { userId: 123 })
+    expect(OError.getFullInfoIncludeCause(err)).to.deep.equal({ userId: 123 })
+  })
+
+  it('merges info from an error and its tags', function () {
+    const err = new OError('foo').withInfo({ projectId: 456 })
+    OError.tag(err, 'failed to foo', { userId: 123 })
+    expect(OError.getFullInfoIncludeCause(err)).to.deep.equal({
+      projectId: 456,
+      userId: 123,
+    })
+  })
+
+  it('merges info from a cause', function () {
+    const err1 = new Error('foo')
+    const err2 = new Error('bar')
+    err1.cause = err2
+    err2.info = { userId: 123 }
+    expect(OError.getFullInfoIncludeCause(err1)).to.deep.equal({ userId: 123 })
+  })
+
+  it('merges info from a nested cause', function () {
+    const err1 = new Error('foo')
+    const err2 = new Error('bar')
+    const err3 = new Error('bar')
+    err1.cause = err2
+    err2.info = { userId: 123 }
+    err2.cause = err3
+    err3.info = { foo: 42 }
+    expect(OError.getFullInfoIncludeCause(err1)).to.deep.equal({
+      userId: 123,
+      foo: 42,
+    })
+  })
+
+  it('merges info from tags with duplicate keys', function () {
+    const err1 = OError.tag(new Error('foo'), 'bar', { userId: 123 })
+    const err2 = OError.tag(err1, 'bat', { userId: 456 })
+    expect(OError.getFullInfoIncludeCause(err2)).to.deep.equal({ userId: 456 })
+  })
+
+  it('works on an error with .info set to a string', function () {
+    const err = new Error('foo')
+    err.info = 'test'
+    expect(OError.getFullInfoIncludeCause(err)).to.deep.equal({})
+  })
+})
+
 describe('OError.getFullStack', function () {
   it('works when given null', function () {
     expect(OError.getFullStack(null)).to.equal('')


### PR DESCRIPTION
For https://github.com/overleaf/issues/issues/3651

This PR is extending `OError.getFullInfo` in merging the error context of nested causes.

As per https://github.com/overleaf/issues/issues/3792 no internal context is leaked to the user.

---

Deployment: squash merge.