### PR TITLE
Add corejs config to allow polyfilling for IE11

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,7 +1,9 @@
 {
   "presets": [
     ["@babel/env", {
-      "targets": ["last 1 year", "ie 11", "firefox esr"]
+      "targets": ["last 1 year", "ie 11", "firefox esr"],
+      "useBuiltIns": "usage",
+      "corejs": { "version": 3 }
     }]
   ]
 }


### PR DESCRIPTION
Does exactly what it says on the tin. Was still seeing errors with the beta on IE11 due to lack of `Symbol` support.