### PR TITLE
Install core-js to fix issue with compiled module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2340,6 +2340,11 @@
       "dev": true,
       "optional": true
     },
+    "core-js": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.3.tgz",
+      "integrity": "sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q=="
+    },
     "core-js-compat": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.8.3.tgz",

--- a/package.json
+++ b/package.json
@@ -59,5 +59,7 @@
     "prettier": "^2.0.2",
     "typescript": "^3.8.3"
   },
-  "dependencies": {}
+  "dependencies": {
+    "core-js": "^3.8.3"
+  }
 }


### PR DESCRIPTION
### Description

Since Babel is configured to inject core-js built-ins where needed, we must also install the core-js package.

Installing OError in an environment which does not already have `core-js` installed will cause an error. [Simple reproduction](https://repl.it/@40thieves/CourageousIllfatedSearchengine#index.js).